### PR TITLE
added the quiet (-q) param to suppress progress output

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,6 +111,7 @@ static void print_usage()
     fprintf(stderr, "  -g gpu-id            gpu device to use (-1=cpu, default=auto) can be 0,1,2 for multi-gpu\n");
     fprintf(stderr, "  -j load:proc:save    thread count for load/proc/save (default=1:2:2) can be 1:2,2,2:2 for multi-gpu\n");
     fprintf(stderr, "  -x                   enable tta mode\n");
+    fprintf(stderr, "  -q                   disable progress printer\n");
     fprintf(stderr, "  -f format            output image format (jpg/png/webp, default=ext/png)\n");
 }
 
@@ -433,12 +434,13 @@ int main(int argc, char** argv)
     int jobs_save = 2;
     int verbose = 0;
     int tta_mode = 0;
+    int quiet = 0;
     path_t format = PATHSTR("png");
 
 #if _WIN32
     setlocale(LC_ALL, "");
     wchar_t opt;
-    while ((opt = getopt(argc, argv, L"i:o:s:t:m:g:j:f:vxh")) != (wchar_t)-1)
+    while ((opt = getopt(argc, argv, L"i:o:s:t:m:g:j:f:vxqh")) != (wchar_t)-1)
     {
         switch (opt)
         {
@@ -473,6 +475,9 @@ int main(int argc, char** argv)
         case L'x':
             tta_mode = 1;
             break;
+        case L'q':
+            quiet = 1;
+            break;
         case L'h':
         default:
             print_usage();
@@ -481,7 +486,7 @@ int main(int argc, char** argv)
     }
 #else // _WIN32
     int opt;
-    while ((opt = getopt(argc, argv, "i:o:s:t:m:g:j:f:vxh")) != -1)
+    while ((opt = getopt(argc, argv, "i:o:s:t:m:g:j:f:vxqh")) != -1)
     {
         switch (opt)
         {
@@ -515,6 +520,9 @@ int main(int argc, char** argv)
             break;
         case 'x':
             tta_mode = 1;
+            break;
+        case 'q':
+            quiet = 1;
             break;
         case 'h':
         default:
@@ -781,7 +789,7 @@ int main(int argc, char** argv)
         {
             int num_threads = gpuid[i] == -1 ? jobs_proc[i] : 1;
 
-            realsr[i] = new RealSR(gpuid[i], tta_mode, num_threads);
+            realsr[i] = new RealSR(gpuid[i], tta_mode, num_threads, quiet);
 
             realsr[i]->load(paramfullpath, modelfullpath);
 

--- a/src/realsr.cpp
+++ b/src/realsr.cpp
@@ -10,7 +10,7 @@
 #include "realsr_preproc_tta.comp.hex.h"
 #include "realsr_postproc_tta.comp.hex.h"
 
-RealSR::RealSR(int gpuid, bool _tta_mode, int num_threads)
+RealSR::RealSR(int gpuid, bool _tta_mode, int num_threads, bool _quiet)
 {
     vkdev = gpuid == -1 ? 0 : ncnn::get_gpu_device(gpuid);
 
@@ -20,6 +20,7 @@ RealSR::RealSR(int gpuid, bool _tta_mode, int num_threads)
     realsr_postproc = 0;
     bicubic_4x = 0;
     tta_mode = _tta_mode;
+    quiet = _quiet;
 }
 
 RealSR::~RealSR()
@@ -478,7 +479,9 @@ int RealSR::process(const ncnn::Mat& inimage, ncnn::Mat& outimage) const
                 cmd.reset();
             }
 
-            fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
+            if (!quiet){
+                fprintf(stderr, "%.2f%%\n", (float)(yi * xtiles + xi) / (ytiles * xtiles) * 100);
+            }
         }
 
         // download

--- a/src/realsr.h
+++ b/src/realsr.h
@@ -13,7 +13,7 @@
 class RealSR
 {
 public:
-    RealSR(int gpuid, bool tta_mode = false, int num_threads = 1);
+    RealSR(int gpuid, bool tta_mode = false, int num_threads = 1, bool quiet = false);
     ~RealSR();
 
 #if _WIN32
@@ -39,6 +39,7 @@ private:
     ncnn::Pipeline* realsr_postproc;
     ncnn::Layer* bicubic_4x;
     bool tta_mode;
+    bool quiet;
 };
 
 #endif // REALSR_H


### PR DESCRIPTION
## Motivation

Currently, the progress output is embedded in the RealSR object, and cannot be controlled. This creates problems especially when the program is used as a library as it will spam lots of messages onto the screen. While it is possible to suppress the messages by suppressing STDERR entirely, it will also suppress error messages, which is undesirable.

![image](https://user-images.githubusercontent.com/21986859/159080581-02fd08d2-ec31-4b7d-a4f5-3e81fe75fd6b.png)

## Behavior Before the Update

Before any changes are made, realsr-ncnn-vulkan will print the progress of the current task:

![image](https://user-images.githubusercontent.com/21986859/159081490-50db2eb2-8db0-4987-9569-d9647f1b6044.png)

## Proposed Changes

I am proposing to add a new param `-q` (quiet) to suppress the progress output. From a consistency standpoint, I'd rather make the output suppressed by default. However, I'd like to not alter the program's default behavior in this PR and leave the choice to @nihui.

## Behavior After the Update

A new parameter `quiet` is added to the RealSR class to control the suppression of progress output. This can also be controlled with the new `-q` argument in the command line argument parser.

```c++
RealSR(int gpuid, bool tta_mode = false, int num_threads = 1, bool quiet = false);
```

After adding the `-q` param, the progress output can be suppressed like such:

![image](https://user-images.githubusercontent.com/21986859/159081694-215ea78c-280f-48ac-827e-7f4e790dd082.png)

## Remarks

I've never written any serious C++ before, so my apologies if I've made any mistakes in the changes.